### PR TITLE
Add getData method for easy row data access

### DIFF
--- a/src/Google/Service/Analytics.php
+++ b/src/Google/Service/Analytics.php
@@ -7876,6 +7876,9 @@ class Google_Service_Analytics_McfDataRows extends Google_Collection
   {
     return $this->primitiveValue;
   }
+  public function getData(){
+    return $this->modelData;
+  }
 }
 
 class Google_Service_Analytics_McfDataRowsConversionPathValue extends Google_Model


### PR DESCRIPTION
getData() will allow easy access for rows without casting toSimpleObject in to an array
